### PR TITLE
Add basic integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pyyaml
+requests

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -3,3 +3,7 @@
 These integration tests are intended to test a fully-functional Nemo-Serve
 instance. While these tests default to https://med-nemo.apps.renci.org/,
 but you can change this by setting the `NEMOSERVE_URL` environmental variable. 
+
+You can run these tests by running `pytest` from the root directory of this
+project or `pytest -s tests/integration` if you only want to run the
+integration tests.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,5 @@
+# Integration tests
+
+These integration tests are intended to test a fully-functional Nemo-Serve
+instance. While these tests default to https://med-nemo.apps.renci.org/,
+but you can change this by setting the `NEMOSERVE_URL` environmental variable. 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -16,7 +16,7 @@ OPENAPI_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/openapi.json')
 DOCS_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/docs/')
 ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
 MODELS_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/models/')
-
+MODELS_EXPECTED = os.getenv('MODELS_EXPECTED', 'tokenClassificationModel').split('|')
 
 def test_openapi():
     response = requests.get(OPENAPI_ENDPOINT)
@@ -42,13 +42,13 @@ def test_models():
     assert len(models) > 0
 
     # At the moment, we only support a single model.
-    assert models == ['tokenClassificationModel']
+    assert models == MODELS_EXPECTED
 
 
 def test_annotate():
     request = {
         "text": "Human brains fit inside human skulls. Influenza is caused by a virus.",
-        "model_name": "tokenClassificationModel"
+        "model_name": MODELS_EXPECTED[0]
     }
     response = requests.post(ANNOTATE_ENDPOINT, json=request)
     assert response.status_code == 200

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,58 @@
+"""
+This test file tests the Nemo-serve API as it currently exists.
+
+This is an integration test: it will test the endpoint you set the
+NEMOSERVE_URL environmental variable to, but will default to
+https://med-nemo.apps.renci.org/
+"""
+
+import os
+import urllib.parse
+
+import requests
+
+NEMOSERVE_URL = os.getenv('NEMOSERVE_URL', 'https://med-nemo.apps.renci.org/')
+OPENAPI_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/openapi.json')
+DOCS_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/docs/')
+ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
+MODELS_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/models/')
+
+
+def test_openapi():
+    response = requests.get(OPENAPI_ENDPOINT)
+    assert response.status_code == 200
+    openapi_response = response.json()
+    assert openapi_response['openapi'] == '3.0.2'
+    assert openapi_response['paths'].keys() == {'/annotate/', '/models/'}
+
+
+def test_docs():
+    response = requests.get(DOCS_ENDPOINT)
+    assert response.status_code == 200
+
+    html = response.content.decode('utf8')
+    assert '<div id="swagger-ui">' in html
+    assert "url: '/openapi.json'" in html
+
+
+def test_models():
+    response = requests.get(MODELS_ENDPOINT)
+    assert response.status_code == 200
+    models = response.json()
+    assert len(models) > 0
+
+    # At the moment, we only support a single model.
+    assert models == ['tokenClassificationModel']
+
+
+def test_annotate():
+    request = {
+        "text": "Human brains fit inside human skulls. Influenza is caused by a virus.",
+        "model_name": "tokenClassificationModel"
+    }
+    response = requests.post(ANNOTATE_ENDPOINT, json=request)
+    assert response.status_code == 200
+    annotated = response.json()
+    assert annotated == [("Human[B-biolink:NamedThing] brains[B-biolink:GrossAnatomicalStructure] fit[0] inside[0] "
+                          "human[B-biolink:NamedThing] skulls[B-biolink:AnatomicalEntity]. "
+                          "Influenza[B-biolink:Disease] is[0] caused[0] by[0] a[0] virus[B-biolink:NamedThing].")]

--- a/tests/integration/test_sapbert.py
+++ b/tests/integration/test_sapbert.py
@@ -1,0 +1,39 @@
+"""
+This test file tests SAPBert via the Nemo-serve API.
+
+This is an integration test: it will test the endpoint you set the
+NEMOSERVE_URL environmental variable to, but will default to
+https://med-nemo-sapbert.apps.renci.org/
+"""
+
+import os
+import urllib.parse
+
+import requests
+
+NEMOSERVE_URL = os.getenv('NEMOSERVE_URL', 'https://med-nemo-sapbert.apps.renci.org/')
+ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
+
+
+def test_identify():
+    """
+    Test whether SAPBert can identify some concepts.
+    """
+    test_cases = [
+        ['human brain', ['Brain', 'D001921']],
+        ['human skulls', ['Skull', 'D012886']],
+        ['influenza', ['Influenza, Human', 'D007251']],
+        ['virus', ['Viruses', 'D014780']]
+    ]
+
+    for test_case in test_cases:
+        query_text = test_case[0]
+        expected_result = test_case[1]
+
+        response = requests.post(ANNOTATE_ENDPOINT, json={
+            "text": query_text,
+            "model_name": "sapbert"
+        })
+        assert response.status_code == 200
+        annotated = response.json()
+        assert annotated == expected_result

--- a/tests/integration/test_sapbert.py
+++ b/tests/integration/test_sapbert.py
@@ -2,7 +2,7 @@
 This test file tests SAPBert via the Nemo-serve API.
 
 This is an integration test: it will test the endpoint you set the
-NEMOSERVE_URL environmental variable to, but will default to
+NEMOSAPBERT_URL environmental variable to, but will default to
 https://med-nemo-sapbert.apps.renci.org/
 """
 
@@ -11,8 +11,8 @@ import urllib.parse
 
 import requests
 
-NEMOSERVE_URL = os.getenv('NEMOSERVE_URL', 'https://med-nemo-sapbert.apps.renci.org/')
-ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
+NEMOSAPBERT_URL = os.getenv('NEMOSAPBERT_URL', 'https://med-nemo-sapbert.apps.renci.org/')
+ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSAPBERT_URL, '/annotate/')
 
 
 def test_identify():


### PR DESCRIPTION
This PR adds some integration tests that can test a Nemo-serve instance at a particular URL (defaulting to https://med-nemo.apps.renci.org/, but configurable with an environmental variable).

@YaphetKG I don't have a ton of experience with testing in Python, so please let me know if there's a better way of doing this! If you think this approach could be useful, I'll add some more tests to make sure Nemo-serve can handle large documents and so on.