### PR TITLE
Add SAPBert tests

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -16,7 +16,7 @@ OPENAPI_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/openapi.json')
 DOCS_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/docs/')
 ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
 MODELS_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/models/')
-
+MODELS_EXPECTED = os.getenv('MODELS_EXPECTED', 'tokenClassificationModel').split('|')
 
 def test_openapi():
     response = requests.get(OPENAPI_ENDPOINT)
@@ -42,13 +42,13 @@ def test_models():
     assert len(models) > 0
 
     # At the moment, we only support a single model.
-    assert models == ['tokenClassificationModel']
+    assert models == MODELS_EXPECTED
 
 
 def test_annotate():
     request = {
         "text": "Human brains fit inside human skulls. Influenza is caused by a virus.",
-        "model_name": "tokenClassificationModel"
+        "model_name": MODELS_EXPECTED[0]
     }
     response = requests.post(ANNOTATE_ENDPOINT, json=request)
     assert response.status_code == 200

--- a/tests/integration/test_sapbert.py
+++ b/tests/integration/test_sapbert.py
@@ -1,0 +1,39 @@
+"""
+This test file tests SAPBert via the Nemo-serve API.
+
+This is an integration test: it will test the endpoint you set the
+NEMOSERVE_URL environmental variable to, but will default to
+https://med-nemo-sapbert.apps.renci.org/
+"""
+
+import os
+import urllib.parse
+
+import requests
+
+NEMOSERVE_URL = os.getenv('NEMOSERVE_URL', 'https://med-nemo-sapbert.apps.renci.org/')
+ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
+
+
+def test_identify():
+    """
+    Test whether SAPBert can identify some concepts.
+    """
+    test_cases = [
+        ['human brain', ['Brain', 'D001921']],
+        ['human skulls', ['Skull', 'D012886']],
+        ['influenza', ['Influenza, Human', 'D007251']],
+        ['virus', ['Viruses', 'D014780']]
+    ]
+
+    for test_case in test_cases:
+        query_text = test_case[0]
+        expected_result = test_case[1]
+
+        response = requests.post(ANNOTATE_ENDPOINT, json={
+            "text": query_text,
+            "model_name": "sapbert"
+        })
+        assert response.status_code == 200
+        annotated = response.json()
+        assert annotated == expected_result

--- a/tests/integration/test_sapbert.py
+++ b/tests/integration/test_sapbert.py
@@ -2,7 +2,7 @@
 This test file tests SAPBert via the Nemo-serve API.
 
 This is an integration test: it will test the endpoint you set the
-NEMOSERVE_URL environmental variable to, but will default to
+NEMOSAPBERT_URL environmental variable to, but will default to
 https://med-nemo-sapbert.apps.renci.org/
 """
 
@@ -11,8 +11,8 @@ import urllib.parse
 
 import requests
 
-NEMOSERVE_URL = os.getenv('NEMOSERVE_URL', 'https://med-nemo-sapbert.apps.renci.org/')
-ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSERVE_URL, '/annotate/')
+NEMOSAPBERT_URL = os.getenv('NEMOSAPBERT_URL', 'https://med-nemo-sapbert.apps.renci.org/')
+ANNOTATE_ENDPOINT = urllib.parse.urljoin(NEMOSAPBERT_URL, '/annotate/')
 
 
 def test_identify():


### PR DESCRIPTION
This PR extends the integration tests in PR #1 to test the Nemo-SAPBert interface as well.