### PR TITLE
Add count input parameter to annotate endpoint

### DIFF
--- a/src/ApiDataStructs.py
+++ b/src/ApiDataStructs.py
@@ -5,12 +5,3 @@ class Query(BaseModel):
     model_name: str
     # count is not required and will default to 1 if nothing is passed
     count: int = 1
-
-    class Config:
-        schema_extra = {
-            "example": {
-                "text": "input text for prediction",
-                "model_name": "tokenclassification or sapbert",
-                "count": 1
-            }
-        }

--- a/src/ApiDataStructs.py
+++ b/src/ApiDataStructs.py
@@ -1,6 +1,16 @@
 from pydantic import BaseModel
 
-
 class Query(BaseModel):
     text: str
     model_name: str
+    # count is not required and will default to 1 if nothing is passed
+    count: int = 1
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "text": "input text for prediction",
+                "model_name": "tokenclassification or sapbert",
+                "count": 1
+            }
+        }

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -195,9 +195,9 @@ class SapbertModelWrapper(ModelWrapper):
         if count == 1:
             nn_index = np.argmin(dist)
             return [{
-                "MESH term": self.all_reps_names[nn_index],
-                "MESH ID": self.all_reps_ids[nn_index],
-                "Distance score": round(dist[0, nn_index], 3)
+                "label": self.all_reps_names[nn_index],
+                "curie": self.all_reps_ids[nn_index],
+                "distance_score": round(dist[0, nn_index], 3)
             }]
         count_dist = np.argpartition(dist, count, axis=None)
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -194,7 +194,11 @@ class SapbertModelWrapper(ModelWrapper):
         dist = cdist(cls_rep.cpu().detach().numpy(), self.all_reps_emb)
         if count == 1:
             nn_index = np.argmin(dist)
-            return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
+            return [{
+                "MESH term": self.all_reps_names[nn_index],
+                "MESH ID": self.all_reps_ids[nn_index],
+                "Distance score": round(dist[0, nn_index], 3)
+            }]
         count_dist = np.argpartition(dist, count, axis=None)
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
         indices = [list(np.asarray(np.where(dist.flatten() == d)).flatten()) for d in result_dist]

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -197,10 +197,10 @@ class SapbertModelWrapper(ModelWrapper):
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
-        logger.error(f'result_dist: {result_dist}, shape: {result_dist.shape}')
-        logger.error(f'concatenated: {[np.where(dist.flatten() == d) for d in result_dist]}')
-        indices = np.concatenate([np.where(dist.flatten() == d) for d in result_dist]).ravel()
-        logger.error(f'indices: {indices}')
+        result_dist = np.unique(result_dist)
+        indices = np.unique(
+            np.asarray([np.asarray(np.where(dist.flatten() == d)).flatten() for d in result_dist])
+        ).ravel()
         return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -194,13 +194,13 @@ class SapbertModelWrapper(ModelWrapper):
         dist = cdist(cls_rep.cpu().detach().numpy(), self.all_reps_emb)
         if count == 1:
             nn_index = np.argmin(dist)
-            return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index]]
+            return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
-        logger.error(f'dist.shape: {dist.shape}')
         result_dist = np.sort(dist[0, count_dist[:count]])
         indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
 
-        return [[self.all_reps_names[idx], self.all_reps_ids[idx], score] for idx, score in zip(indices, result_dist)]
+        return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(score, 3)] for idx, score in zip(indices,
+                                                                                                          result_dist)]
 
 
 class ModelFactory:

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -195,7 +195,7 @@ class SapbertModelWrapper(ModelWrapper):
         if count == 1:
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index]]
-        count_dist = np.argpartition(dist, count)
+        count_dist = np.argpartition(dist, count, axis=None)
         result_dist = np.sort(dist[count_dist[:count]])
         indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
         return [[self.all_reps_names[idx], self.all_reps_ids[idx]] for idx in indices]

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,12 +196,8 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
-        logger.error(f'count_dist: {count_dist}')
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
-        logger.error(f'count_dist dist: {dist[0, count_dist[:count]]}')
-        logger.error(f'result_dist: {result_dist}')
-        indices = np.unique(np.concatenate([np.where(dist == d) for d in result_dist])).ravel()
-        logger.error(f'indices: {indices}')
+        indices = np.concatenate([np.where(dist.flatten() == d) for d in result_dist]).ravel()
         return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -199,7 +199,14 @@ class SapbertModelWrapper(ModelWrapper):
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
         indices = [list(np.asarray(np.where(dist.flatten() == d)).flatten()) for d in result_dist]
         indices = sum(indices, [])
-        return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
+        return [
+            {
+                "MESH term": self.all_reps_names[idx],
+                "MESH ID": self.all_reps_ids[idx],
+                "Distance score": round(dist[0, idx], 3)
+            }
+            for idx in indices[:count]
+        ]
 
 
 class ModelFactory:

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,11 +196,8 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
-        result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
-        result_dist = np.unique(result_dist)
-        indices = np.unique(
-            np.asarray([np.asarray(np.where(dist.flatten() == d)).flatten() for d in result_dist])
-        ).ravel()
+        result_dist = np.unique(np.sort(dist[0, count_dist[:count]], axis=None))
+        indices = [list(np.asarray(np.where(dist.flatten() == d)).flatten()) for d in result_dist]
         return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,8 +196,12 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
+        logger.error(f'count_dist: {count_dist}')
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
+        logger.error(f'count_dist dist: {dist[0, count_dist[:count]]}')
+        logger.error(f'result_dist: {result_dist}')
         indices = np.unique(np.concatenate([np.where(dist == d) for d in result_dist])).ravel()
+        logger.error(f'indices: {indices}')
         return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,8 +196,9 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
-        result_dist = np.unique(np.sort(dist[0, count_dist[:count]], axis=None))
+        result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
         indices = [list(np.asarray(np.where(dist.flatten() == d)).flatten()) for d in result_dist]
+        indices = sum(indices, [])
         return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -195,8 +195,6 @@ class SapbertModelWrapper(ModelWrapper):
         if count == 1:
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index]]
-        if count >= len(dist):
-            return []
         count_dist = np.argpartition(dist, count)
         result_dist = np.sort(dist[count_dist[:count]])
         indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -205,9 +205,9 @@ class SapbertModelWrapper(ModelWrapper):
         indices = sum(indices, [])
         return [
             {
-                "MESH term": self.all_reps_names[idx],
-                "MESH ID": self.all_reps_ids[idx],
-                "Distance score": round(dist[0, idx], 3)
+                "label": self.all_reps_names[idx],
+                "curie": self.all_reps_ids[idx],
+                "distance_score": round(dist[0, idx], 3)
             }
             for idx in indices[:count]
         ]

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,9 +196,9 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
-        result_dist = np.sort(dist[0, count_dist[:count]])
-        indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
-        return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices]
+        result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
+        indices = np.unique(np.concatenate([np.where(dist == d) for d in result_dist])).ravel()
+        return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 
 class ModelFactory:

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,6 +196,9 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index]]
         count_dist = np.argpartition(dist, count, axis=None)
+        logger.debug(f'count: {count}, dist shape: {dist.shape}')
+        logger.error(f'count_dist: {count_dist[:count]}')
+        logger.error(f'dist: {dist[count_dist[:count]]}')
         result_dist = np.sort(dist[count_dist[:count]])
         indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
         return [[self.all_reps_names[idx], self.all_reps_ids[idx]] for idx in indices]

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -196,12 +196,11 @@ class SapbertModelWrapper(ModelWrapper):
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index]]
         count_dist = np.argpartition(dist, count, axis=None)
-        logger.debug(f'count: {count}, dist shape: {dist.shape}')
-        logger.error(f'count_dist: {count_dist[:count]}')
-        logger.error(f'dist: {dist[count_dist[:count]]}')
-        result_dist = np.sort(dist[count_dist[:count]])
+        logger.error(f'dist.shape: {dist.shape}')
+        result_dist = np.sort(dist[0, count_dist[:count]])
         indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
-        return [[self.all_reps_names[idx], self.all_reps_ids[idx]] for idx in indices]
+
+        return [[self.all_reps_names[idx], self.all_reps_ids[idx], score] for idx, score in zip(indices, result_dist)]
 
 
 class ModelFactory:

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -195,9 +195,12 @@ class SapbertModelWrapper(ModelWrapper):
         if count == 1:
             nn_index = np.argmin(dist)
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index]]
-
-        sorted_dist = np.argsort(dist)[:count]
-        return [[self.all_reps_names[idx], self.all_reps_ids[idx]] for idx in sorted_dist]
+        if count >= len(dist):
+            return []
+        count_dist = np.argpartition(dist, count)
+        result_dist = np.sort(dist[count_dist[:count]])
+        indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
+        return [[self.all_reps_names[idx], self.all_reps_ids[idx]] for idx in indices]
 
 
 class ModelFactory:

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -198,9 +198,7 @@ class SapbertModelWrapper(ModelWrapper):
         count_dist = np.argpartition(dist, count, axis=None)
         result_dist = np.sort(dist[0, count_dist[:count]])
         indices = np.concatenate([np.where(dist==d) for d in result_dist]).ravel()
-
-        return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(score, 3)] for idx, score in zip(indices,
-                                                                                                          result_dist)]
+        return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices]
 
 
 class ModelFactory:

--- a/src/ModelSingleton.py
+++ b/src/ModelSingleton.py
@@ -197,7 +197,10 @@ class SapbertModelWrapper(ModelWrapper):
             return [self.all_reps_names[nn_index], self.all_reps_ids[nn_index], round(dist[0, nn_index], 3)]
         count_dist = np.argpartition(dist, count, axis=None)
         result_dist = np.sort(dist[0, count_dist[:count]], axis=None)
+        logger.error(f'result_dist: {result_dist}, shape: {result_dist.shape}')
+        logger.error(f'concatenated: {[np.where(dist.flatten() == d) for d in result_dist]}')
         indices = np.concatenate([np.where(dist.flatten() == d) for d in result_dist]).ravel()
+        logger.error(f'indices: {indices}')
         return [[self.all_reps_names[idx], self.all_reps_ids[idx], round(dist[0, idx], 3)] for idx in indices[:count]]
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,14 +19,14 @@ def json_line_iterator(file_path):
         for line in stream:
             yield json.loads(line)
 
-def annotate_text(text, model_name):
+def annotate_text(text, model_name, count=1):
     """
     run Model on text
     :param text: input text to run predictions on
     :param model_name: name of the model to use
     :return: prediction result
     """
-    return ModelFactory.query_model(model_name=model_name,query_text=text)
+    return ModelFactory.query_model(model_name=model_name,query_text=text, query_count=count)
 
 def append_json_to_file(data, output_path):
     """

--- a/src/server.py
+++ b/src/server.py
@@ -25,7 +25,7 @@ def init_nlp_model():
 async def annotate_text(query: Query):
     if query.model_name not in ModelFactory.get_model_names():
         return {"error": f"please provide a valid model name from {ModelFactory.get_model_names()}"}, 400
-    return ModelFactory.query_model(model_name=query.model_name, query_text=query.text)
+    return ModelFactory.query_model(model_name=query.model_name, query_text=query.text, query_count=query.count)
 
 
 @app.get("/models/")


### PR DESCRIPTION
Add count input parameter to annotate endpoint to allow sapbert model prediction to return multiple number of terms, ids and scores.