### PR TITLE
Convert output format to JSON

### DIFF
--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -236,16 +236,16 @@ def annotate_variable_using_scigraph(var_name, desc, permissible_values):
     # Normalize identifiers.
     for annot in annotations:
         # Try to normalize the ID.
-        mesh = annot['id']
+        curie = annot['id']
 
         response = requests.get(NODE_NORM_ENDPOINT, {
-            'curie': mesh,
+            'curie': curie,
             'conflate': 'true'
         })
         if not response.ok:
             pass
         else:
-            result = response.json().get(mesh, {})
+            result = response.json().get(curie, {})
             if result:
                 normalized_id = result.get('id', {})
                 normalized_identifier = normalized_id.get('identifier')
@@ -255,6 +255,7 @@ def annotate_variable_using_scigraph(var_name, desc, permissible_values):
                     pass
                 else:
                     annot['nn_id'] = normalized_identifier
+                    annot['nn_category'] = result.get('type')[0]
                     annot['nn_label'] = normalized_label
 
     return annotations
@@ -313,12 +314,10 @@ def annotate_dbgap_data_dict(method):
                 assert Exception("input method must be sapbert, scigraph, or nameres.")
 
             for annotation in annotations:
-                if 'nn_id' not in annotation:
-                    annotation['normalized_id'] = annotation['curie']
-                    annotation['normalized_label'] = annotation.get('label', '')
-                elif 'nn_id' in annotation:
+                if 'nn_id' in annotation:
                     annotation['normalized_id'] = annotation['nn_id']
                     annotation['normalized_label'] = annotation['nn_label']
+                    annotation['normalized_category'] = annotation.get('nn_category', '')
 
 def annotation_string(annotation):
     """

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -169,7 +169,6 @@ def annotate_variable_using_babel_nemoserve(var_name, desc, permissible_values, 
             denotation['score'] = first_result['score']
             denotation['label'] = first_result['name']
             denotation['obj'] = f"{first_result['curie']} ({first_result['name']}, score: {first_result['score']})"
-            denotation['score'] = first_result['score']
             denotation['query_bl_type'] = bl_type
             denotation['category'] = first_result['category']
         else:  # nameres

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -61,6 +61,9 @@ OUTPUT_SCIGRAPH_ANNOTATION_FILE = os.path.join(OUTPUT_DIR,
 OUTPUT_NAMERES_ANNOTATION_FILE = os.path.join(OUTPUT_DIR,
                                               "nameres_annot_output.txt")
 OUTPUT_SUMMARY_FILE = os.path.join(OUTPUT_DIR, "annotation_summary_output.csv")
+OUTPUT_SAPBERT_ANNOTATION_FILE = os.path.join(OUTPUT_DIR, "sapbert_annot_output.jsonl")
+OUTPUT_SCIGRAPH_ANNOTATION_FILE = os.path.join(OUTPUT_DIR, "scigraph_annot_output.jsonl")
+OUTPUT_NAMERES_ANNOTATION_FILE = os.path.join(OUTPUT_DIR, "nameres_annot_output.jsonl")
 # Which dbGaP data dictionaries should we test? This should be a URL that points directly to a data_dict.xml file.
 DBGAP_DATA_DICTS_TO_TEST = [
     'https://ftp.ncbi.nlm.nih.gov/dbgap/studies/phs000810/phs000810.v1.p1/pheno_variable_summaries/phs000810.v1.pht004715.v1.HCHS_SOL_Cohort_Subject_Phenotypes.data_dict.xml',

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -163,7 +163,7 @@ def annotate_variable_using_babel_nemoserve(var_name, desc, permissible_values, 
         first_result = result[0]
 
         denotation = dict(token)
-        denotation['id'] = f"{first_result['curie']}"
+        denotation['id'] = first_result['curie']
         denotation['text'] = text
         if method == 'sapbert':
             denotation['score'] = first_result['score']

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -314,7 +314,7 @@ def annotate_dbgap_data_dict(method):
 
             for annotation in annotations:
                 if 'nn_id' not in annotation:
-                    annotation['normalized_id'] = annotation['obj']
+                    annotation['normalized_id'] = annotation['curie']
                     annotation['normalized_label'] = annotation.get('label', '')
                 elif 'nn_id' in annotation:
                     annotation['normalized_id'] = annotation['nn_id']

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -300,7 +300,7 @@ def annotate_dbgap_data_dict(method):
                 'var_type': var_type,
                 'var_desc': var_desc,
                 'method': method,
-                'values': list(variable.findall('value')),
+                'values': list(values),
                 'annotations': []
             }
 

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -312,7 +312,7 @@ def annotate_dbgap_data_dict(method):
             for annotation in annotations:
                 if 'nn_id' not in annotation:
                     annotation['normalized_id'] = annotation['obj']
-                    annotation['normalized_label'] = annotation['name']
+                    annotation['normalized_label'] = annotation.get('label', '')
                 elif 'nn_id' in annotation:
                     annotation['normalized_id'] = annotation['nn_id']
                     annotation['normalized_label'] = annotation['nn_label']

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -165,16 +165,15 @@ def annotate_variable_using_babel_nemoserve(var_name, desc, permissible_values, 
         denotation = dict(token)
         denotation['id'] = first_result['curie']
         denotation['text'] = text
+        denotation['query_bl_type'] = bl_type
         if method == 'sapbert':
             denotation['score'] = first_result['score']
             denotation['label'] = first_result['name']
             denotation['obj'] = f"{first_result['curie']} ({first_result['name']}, score: {first_result['score']})"
-            denotation['query_bl_type'] = bl_type
             denotation['category'] = first_result['category']
         else:  # nameres
             denotation['label'] = first_result['label']
             denotation['obj'] = f"{first_result['curie']} ({first_result['types'][0]}: {first_result['label']})"
-            denotation['query_bl_type'] = bl_type
             denotation['category'] = first_result['types'][0]
 
         # These should already be normalized. So let's set nn_id and nn_label.


### PR DESCRIPTION
This PR updates PR #24 to add support for exporting results as JSON. An explanation of the fields:
- var_id: the variable ID from dbGaP
- var_name: the variable name from dbGaP
- var_type: the dbGaP type
- var_desc: the dbGaP description of the variable
- method: the method being used (i.e. `nameres`, `sapbert` or `scigraph`)
- values: a list of encoded values, in the format "code: value" (e.g. `1: Reported taking diltiazem`)
- annotations:  a list of annotations, in the format:
  - text: the text in the input text identified as a biomedical entity
  - id: the CURIE for this concept returned by the tool
  - span: a dictionary with two items:
    - begin: the index in the source text where the match begins
    - end: the index in source text where the match ends
  - obj: a formatted string describing the match, including score if included.
  - query_bl_type: the Biolink type suggested by the NER process (for NameRes and SAPBERT, this is BioMegatron)
  - category: the Biolink type returned by the entity linking (should be equal to or more specific than query_bl_type)
  - nn_id/nn_category/nn_label: the CURIE, category and label returned by NodeNorm (only applicable to scigraph, since nameres and sapbert are both already normalized to Babel)

WIP:
- [ ] Need to recheck.
- [ ] Need to add some context.