### PR TITLE
Update nameres to v1.3.8

### DIFF
--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -150,7 +150,7 @@ def annotate_variable_using_babel_nemoserve(var_name, desc, permissible_values, 
 
             # Some NameRes v1.3.8-specific options.
             if 'sri-dev.apps' in NAMERES_ENDPOINT:
-                nameres_options['autocomplete'] = 'true'
+                nameres_options['autocomplete'] = 'false'
                 nameres_options['exclude_prefixes'] = 'UMLS'
 
             if bl_type:

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -156,7 +156,7 @@ def annotate_variable_using_babel_nemoserve(var_name, desc, permissible_values, 
             if bl_type:
                 nameres_options['biolink_type'] = bl_type
 
-            logging.debug(f"Request to NameRes {NAMERES_ENDPOINT}: {nameres_options}")
+            logging.info(f"Request to NameRes {NAMERES_ENDPOINT}: {nameres_options}")
             response = requests.post(NAMERES_ENDPOINT, data=nameres_options)
             logging.debug(f"Response from nameres: {response.content}")
             if not response.status_code == 200:

--- a/tests/integration/test_dbgap.py
+++ b/tests/integration/test_dbgap.py
@@ -162,7 +162,7 @@ def annotate_variable_using_babel_nemoserve(var_name, desc, permissible_values, 
                 nameres_options['biolink_type'] = bl_type
 
             logging.info(f"Request to NameRes {NAMERES_ENDPOINT}: {nameres_options}")
-            response = requests.get(NAMERES_ENDPOINT, data=nameres_options)
+            response = requests.get(NAMERES_ENDPOINT, params=nameres_options)
             logging.debug(f"Response from nameres: {response.content}")
             if not response.status_code == 200:
                 logging.error(f"Server error from NameRes for text '{text}': {response}")


### PR DESCRIPTION
NameRes v1.3.8 (currently only available at https://name-resolution-sri-dev.apps.renci.org/ but should be on NameRes Dev by the time this is reviewed/merged) introduces some new options that we have not previously used:
- It now returns its score for each result.
- It now provides an `autocomplete` flag -- if set to false, NameRes will not assume that the last word is incomplete.
- It now provides an `exclude_prefixes` flag that allows identifiers with particular prefixes to be excluded.

I also experimentally added an option to exclude all UMLS results from all our queries at once.

WIP